### PR TITLE
[breaking] Add next-unattested to time range path output

### DIFF
--- a/olivia/src/sources/time_tests.rs
+++ b/olivia/src/sources/time_tests.rs
@@ -28,7 +28,7 @@ macro_rules! run_time_db_tests {
                 $($init)*;
                 let look_ahead = Duration::seconds(2);
                 let interval = Duration::seconds(1);
-                let fudge = Duration::milliseconds(300);
+                let fudge = Duration::milliseconds(400);
                 let initial_time = now();
 
                 let mut stream = Box::pin(TimeEventStream {
@@ -96,7 +96,7 @@ macro_rules! run_time_db_tests {
                     "we should have waited for 1 second"
                 );
                 assert!(
-                    now() < initial_time + Duration::milliseconds(1000) + fudge,
+                    now() < initial_time + Duration::seconds(1) + fudge,
                     "shouldn't have waited too much"
                 );
             }

--- a/olivia_core/src/node.rs
+++ b/olivia_core/src/node.rs
@@ -6,11 +6,13 @@ pub enum ChildDesc {
     List {
         list: Vec<Child>,
     },
+    #[serde(rename_all = "kebab-case")]
     Range {
         #[serde(flatten)]
         range_kind: RangeKind,
-        start: Option<Child>,
-        end: Option<Child>,
+        start: Option<String>,
+        next_unattested: Option<String>,
+        end: Option<String>,
     },
 }
 

--- a/olivia_core/src/path.rs
+++ b/olivia_core/src/path.rs
@@ -51,7 +51,9 @@ impl<'a> PathRef<'a> {
     }
 
     pub fn segments(self) -> impl Iterator<Item = &'a str> {
-        self.0[1..].split('/')
+        let mut iter = self.0.split('/');
+        let _ = iter.next();
+        iter
     }
 
     pub fn strip_event(self) -> Option<(PathRef<'a>, &'a str)> {
@@ -138,6 +140,10 @@ impl Path {
     pub fn from_dt(dt: NaiveDateTime) -> Self {
         Path(format!("/{}", dt.format("%FT%T")))
     }
+
+    pub fn into_child(self, name: &str) -> Self {
+        Path(self.0 + "/" + name)
+    }
 }
 
 impl fmt::Display for Path {
@@ -221,5 +227,17 @@ mod test {
             Path::from_str("/bar").unwrap().prefix_path(PathRef::root()),
             Path::from_str("/bar").unwrap()
         );
+    }
+
+    #[test]
+    fn segments() {
+        assert_eq!(
+            Path::from_str("/foo/bar")
+                .unwrap()
+                .as_path_ref()
+                .segments()
+                .collect::<Vec<_>>(),
+            vec!["foo", "bar"]
+        )
     }
 }


### PR DESCRIPTION
e.g.
```
{
  "events": [],
  "children": {
    "kind": "range",
    "range-kind": "time",
    "interval": 60,
    "start": "2021-10-09T06:12:00",
    "next-unattested": "2021-10-09T06:13:00",
    "end": "2021-10-09T06:17:00"
  }
}
```
`next-unattested` means the child with the next event that should be attested to by expected-outcome-time.
The practical reason is so I can set the default value for the datetime picker (so its default value is the next one).

The breaking change is that I also stripped the node info from `start` and `end` and just give the node name.
